### PR TITLE
Clean up the HTTP endpoint naming and avoid unnecessary JSON serialization

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -22,13 +22,14 @@ set :port, 8334
 set :bind, '0.0.0.0'
 set :erb, :trim => '-'
 
-get '/beer' do
-  @kegerator = JSON.parse(whats_on_tap(session))
+get '/' do
+  @kegerator = whats_on_tap(session)
   erb :index
 end
 
-get '/' do
-   whats_on_tap(session)
+get '/api/v1/beer' do
+  content_type :json
+  whats_on_tap(session).to_json
 end
 
 def whats_on_tap(session)
@@ -52,5 +53,5 @@ def whats_on_tap(session)
     beertap[:tap_date]  = row[6]
     kegerator << beertap
   end
-  kegerator.to_json
+  kegerator
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -28,16 +28,16 @@
           <% count = count +1 %>
         <td align="center" valign="top">
           <table cellpadding="0" cellspacing="0" border="0" style="border:3px; border-color: #FFFFFF; border-style:solid;">
-              <td><b><%= keg['tap'] %></b></td>
+              <td><b><%= keg[:tap] %></b></td>
             </tr>
             <tr>
                 <td colspan="2" width="100%" align="left" valign="top" style="padding:10px; margin:0px;">
-                <h2><%= keg['brewery'] %></h2>
-                <h1><%= keg['beer_name'] %></h1>
-                Style: <%= keg['style'] %> <br/>
-                Beer Advocate: <a href='<%= keg['link'] %>'>Link</a> <br />
-                Abv: <%= keg['abv'].gsub('%', '') %>% <br />
-                Tap Date: <%= keg['tap_date'] %><br />
+                <h2><%= keg[:brewery] %></h2>
+                <h1><%= keg[:beer_name] %></h1>
+                Style: <%= keg[:style] %> <br/>
+                Beer Advocate: <a href='<%= keg[:link] %>'>Link</a> <br />
+                Abv: <%= keg[:abv].gsub('%', '') %>% <br />
+                Tap Date: <%= keg[:tap_date] %><br />
               </td>
           </table>
         </td>


### PR DESCRIPTION
This commit does two things:
1. It moves the HTTP endpoints around so that they're a bit more
   typical. The user-visible page is now at `/`, with the API endpoint
   namespaced and versioned.
2. It moves JSON serialization from the `whats_on_top` internal
   function to the sinatra hook, avoiding serialization when we're
   using the structured data internally.
