### PR TITLE
Use tsv export url to avoid authing with google drive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.n
 # anybody that access to the correct spreadsheet can run/use the application.
 # It's just easier.
 RUN yum -y install ruby rubygems ruby-devel rubygem-nokogiri rubygem-bundler rubygem-json gcc make gcc-c++
-# There are no rpms for google_drive, sinatra or thin yet in EL/EPEL7
-RUN gem install --no-rdoc --no-ri -v 0.3.6 google_drive
+# There are no rpms for sinatra or thin yet in EL/EPEL7
 RUN gem install --no-rdoc --no-ri sinatra thin
 
 # The application will run out of /beer_endpoint as the user beer_endpoint

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ image:
 
 
 run:
-	docker run -d -e "GOOGLE_DRIVE_PASSWORD=$(GOOGLE_DRIVE_PASSWORD)" -e "GOOGLE_DRIVE_USERNAME=$(GOOGLE_DRIVE_USERNAME)" --restart=on-failure:10  --name beer_endpoint -p 8334:8334  centos/beer_endpoint
+	docker run -d --restart=on-failure:10  --name beer_endpoint -p 8334:8334  centos/beer_endpoint
 
 clean:
 	docker stop beer_endpoint || true


### PR DESCRIPTION
Login with username/password is no longer supported by google drive, and
OAuth is a gigantic pain for non-browser apps. Since the beer
spreadsheet is publically accessible *anyway*, jumping through all these
hoops to authenticate is unnecessary. Now we use the tsv export url to
fetch the data, which works without any fuss.

Also simplified the logic for processing the data.