### PR TITLE
Links and ondeck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,8 @@ source 'https://rubygems.org' do
   gem 'json'
   gem 'rake'
   gem 'shotgun'
+
+group :development do
+  gem 'rerun'
+end  
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -26,8 +26,8 @@
           <p><span class="label">Style:</span> <span class="value"><%= keg[:style] %></span></p>
           <p><span class="label">ABV:</span> <span class="value"><%= keg[:abv] %>%</p>
           <p><span class="label">IBU:</span> <span class="value"><%= keg[:ibu] %></span></p>
-          <p><span class="label">Tap Date:</span> <span class="value"><%= keg[:tap_date] %></span></p>
-          <p><span class="label">Beer Advocate:</span> <span class="value"><a href='<%= keg[:link] %>'>Link</a></p>
+          <p><span class="label">Tap Date:</span> <span class="value"><%= keg[:tap_date] %></span></p><% if keg[:link] != 'empty' %>
+          <p><span class="label"><%= keg[:link].include?('untappd.com') ? 'Untappd:' : 'Beer Advocate:' %></span> <span class="value"><a href='<%= keg[:link] %>'>Link</a></p><% end %>
         </div>
       </div>
 


### PR DESCRIPTION
This PR does two things:

1. Only shows the line with the link if a URL is provided and changes it from "Beer Advocate" to "Untappd" if the URL contains `untappd.com`. The default value of the link was changed to facilitate the conditional display code.
2. Adds an API endporint for the on deck sheet. To do this I took the existing `whats_on_tap(session)` method and added a parameter for url. I then renamed it to `parse_sheet` and made two new methods that call it: `whats_on_tap(session)` and `whats_on_deck(session)`.

The rerun gem was also added to make developing easier.