### PR TITLE
Force output from google sheets to be UTF-8

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -49,6 +49,7 @@ def parse_sheet(session,url)
   rows = open(url).each_line
 
   rows.drop(1).map do |row|
+    row.force_encoding('UTF-8')
     values = row.split("\t").map(&:strip)
     v = []
     # :tap, :brewery, :beer_name, :style, :abv, :ibu, :link, :tap_date


### PR DESCRIPTION
Ruby defaults to returning data from HTTP requests as ASCII-8BIT. We can trust that Google data is UTF-8 (I hope), so we just force the strings we get to be a useful encoding.